### PR TITLE
doc: remove dead link

### DIFF
--- a/evdns.c
+++ b/evdns.c
@@ -28,7 +28,6 @@
  *
  * Async DNS Library
  * Adam Langley <agl@imperialviolet.org>
- * http://www.imperialviolet.org/eventdns.html
  * Public Domain code
  *
  * This software is Public Domain. To view a copy of the public domain dedication,


### PR DESCRIPTION
The link is dead and an archived page cannot be found in the
web.archive.org.